### PR TITLE
feat: Secure API key with server-side proxy

### DIFF
--- a/src/app/api/crypto/[...path]/route.ts
+++ b/src/app/api/crypto/[...path]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const COINGECKO_BASE_URL = 'https://api.coingecko.com/api/v3';
+
+type RouteContext = {
+  params: {
+    path: string[];
+  };
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const apiKey = process.env.COINGECKO_API_KEY;
+
+    if (!apiKey) {
+      return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+    }
+
+    const { path } = context.params;
+
+    const endpoint = path.join('/');
+
+    const searchParams = new URL(request.url).searchParams;
+
+    const queryParams = new URLSearchParams(searchParams);
+    queryParams.set('x_cg_demo_api_key', apiKey);
+
+    const coinGeckoUrl = `${COINGECKO_BASE_URL}/${endpoint}?${queryParams.toString()}`;
+
+    const response = await fetch(coinGeckoUrl, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      next: {
+        revalidate: 60,
+      },
+    });
+
+    if (response.status === 429) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded. Please try again later.' },
+        { status: 429 }
+      );
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('CoinGecko API error:', response.status, errorText);
+      return NextResponse.json(
+        { error: 'Failed to fetch data from CoinGecko' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data, {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
+      },
+    });
+  } catch (error) {
+    console.error('Proxy API error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -68,9 +68,7 @@ export default function Navbar() {
       setIsLoading(true);
       const fetchCryptocurrencies = async () => {
         try {
-          const response = await fetch(
-            `https://api.coingecko.com/api/v3/search?query=${searchQuery}&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`
-          );
+          const response = await fetch(`/api/crypto/search?query=${searchQuery}`);
           const data = await response.json();
           setSearchResults(data.coins);
         } catch (error) {

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -99,23 +99,23 @@ interface MarketChartApiResponse {
 export const cryptoApi = createApi({
   reducerPath: 'cryptoApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'https://api.coingecko.com/api/v3',
+    baseUrl: '/api/crypto',
   }),
   tagTypes: ['CoinMarkets'],
   endpoints: (builder) => ({
     getGlobalData: builder.query<{ data: GlobalData }, void>({
-      query: () => `/global?x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`,
+      query: () => `/global`,
     }),
     getCoinMarkets: builder.query<CoinMarketData[], string>({
       query: (currency) =>
-        `/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=100&page=1&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`,
+        `/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=100&page=1`,
     }),
     getCoinMarketChart: builder.query<
       CoinChartData,
       { coinId: string; currency: string; days: string }
     >({
       query: ({ coinId, currency, days }) =>
-        `/coins/${coinId}/market_chart?vs_currency=${currency}&days=${days}&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`,
+        `/coins/${coinId}/market_chart?vs_currency=${currency}&days=${days}`,
       transformResponse: (response: MarketChartApiResponse, meta, arg) => {
         return {
           id: arg.coinId,
@@ -126,11 +126,11 @@ export const cryptoApi = createApi({
     }),
     getCoinDetails: builder.query<CoinDetails, string>({
       query: (coinId) =>
-        `/coins/${coinId}?localization=false&tickers=false&market_data=false&community_data=false&developer_data=false&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`,
+        `/coins/${coinId}?localization=false&tickers=false&market_data=false&community_data=false&developer_data=false`,
     }),
     getCoinMarketPaginated: builder.query<CoinMarketData[], { currency: string; page: number }>({
       query: ({ currency, page }) =>
-        `/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=20&page=${page}&sparkline=true&price_change_percentage=1h,24h,7d&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`,
+        `/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=20&page=${page}&sparkline=true&price_change_percentage=1h,24h,7d`,
       // Group queries by currency only to consolidate pages
       serializeQueryArgs: ({ queryArgs }) => queryArgs.currency,
       // Force a re-fetch if page or currency changes
@@ -154,7 +154,7 @@ export const cryptoApi = createApi({
     getCoinPageInfo: builder.query<CoinInfo, string>({
       // Takes coinId string, returns CoinInfo
       query: (coinId) =>
-        `/coins/${coinId}?localization=false&tickers=false&market_data=true&community_data=true&developer_data=false&sparkline=false&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`,
+        `/coins/${coinId}?localization=false&tickers=false&market_data=true&community_data=true&developer_data=false&sparkline=false`,
       // Optional: Add providesTags if this data might be invalidated by other actions
       // providesTags: (result, error, coinId) => [{ type: 'CoinDetail', id: coinId }],
     }),


### PR DESCRIPTION
- Create API proxy route at src/app/api/crypto/[...path]/route.ts
- Update RTK Query to use /api/crypto instead of direct CoinGecko URL
- Remove API key from all client-side requests
- Update Navbar search to use proxy endpoint

API key is now server-side only and never exposed to client.