### PR TITLE
fix: add iOS Safari height fixes and GPU layer forcing for mobile navbar

### DIFF
--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -26,6 +26,8 @@ export default function MobileNavbar() {
       className="fixed inset-x-0 bottom-0 z-[9999] flex w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
         paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))',
+        WebkitTransform: 'translate3d(0, 0, 0)',
+        transform: 'translate3d(0, 0, 0)',
       }}
     >
       <Link href={`/${currencyQueryString}`} className={getMobileLinkClasses(pathname === '/')}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,12 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Ensure proper touch behavior on iOS */
+/* iOS Safari height and scroll fixes */
 html {
+  height: 100%;
+  height: -webkit-fill-available;
   -webkit-overflow-scrolling: touch;
 }
 
-/* Prevent fixed elements from shifting on iOS during scroll */
+body {
+  min-height: 100%;
+  min-height: -webkit-fill-available;
+}
+
+/* Prevent overscroll bounce on iOS */
 @supports (padding-bottom: env(safe-area-inset-bottom)) {
   html,
   body {


### PR DESCRIPTION
- Add -webkit-fill-available height to html/body for proper iOS viewport
- Add translate3d(0,0,0) transform to force GPU compositing layer
- Prevents navbar from shifting during scroll on iOS Safari