### PR TITLE
refactor: simplify iOS navbar padding and remove GPU transform

### DIFF
--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -25,9 +25,7 @@ export default function MobileNavbar() {
     <nav
       className="fixed inset-x-0 bottom-0 z-[9999] flex w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
-        paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))',
-        WebkitTransform: 'translate3d(0, 0, 0)',
-        transform: 'translate3d(0, 0, 0)',
+        paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
       }}
     >
       <Link href={`/${currencyQueryString}`} className={getMobileLinkClasses(pathname === '/')}>

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -23,7 +23,7 @@ export default function MobileNavbar() {
 
   return (
     <nav
-      className="fixed left-0 right-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full max-w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
+      className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
         bottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
         paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -23,7 +23,7 @@ export default function MobileNavbar() {
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
+      className="fixed left-0 right-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full max-w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
         bottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
         paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { HomeIcon } from '../icons/HomeIcon';
 import { PortfolioIcon } from '../icons/PortfolioIcon';
@@ -16,15 +17,38 @@ const getMobileLinkClasses = (isActive: boolean) => {
 };
 
 export default function MobileNavbar() {
+  const [visualBottomOffset, setVisualBottomOffset] = useState(0);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currencyParam = searchParams?.get('currency');
   const currencyQueryString = currencyParam ? `?currency=${currencyParam}` : '';
 
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const updateOffset = () => {
+      const offset = Math.max(0, window.innerHeight - (viewport.height + viewport.offsetTop));
+      setVisualBottomOffset(offset);
+    };
+
+    updateOffset();
+    viewport.addEventListener('resize', updateOffset);
+    viewport.addEventListener('scroll', updateOffset);
+    window.addEventListener('orientationchange', updateOffset);
+
+    return () => {
+      viewport.removeEventListener('resize', updateOffset);
+      viewport.removeEventListener('scroll', updateOffset);
+      window.removeEventListener('orientationchange', updateOffset);
+    };
+  }, []);
+
   return (
     <nav
       className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
+        bottom: `calc(${visualBottomOffset}px + var(--mobile-nav-safe, env(safe-area-inset-bottom)))`,
         paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
         WebkitTransform: 'translateZ(0)',
         transform: 'translateZ(0)',

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -25,7 +25,6 @@ export default function MobileNavbar() {
     <nav
       className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
-        bottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
         paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
       }}
     >

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -1,5 +1,7 @@
 'use client';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { HomeIcon } from '../icons/HomeIcon';
 import { PortfolioIcon } from '../icons/PortfolioIcon';
@@ -16,16 +18,21 @@ const getMobileLinkClasses = (isActive: boolean) => {
 };
 
 export default function MobileNavbar() {
+  const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currencyParam = searchParams?.get('currency');
   const currencyQueryString = currencyParam ? `?currency=${currencyParam}` : '';
 
-  return (
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const navbar = (
     <nav
-      className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
+      className="fixed inset-x-0 bottom-0 z-[9999] flex w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
-        paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
+        paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))',
       }}
     >
       <Link href={`/${currencyQueryString}`} className={getMobileLinkClasses(pathname === '/')}>
@@ -48,4 +55,13 @@ export default function MobileNavbar() {
       </Link>
     </nav>
   );
+
+  // Use portal to render directly into document.body, bypassing any
+  // parent transforms/overflow from NextUIProvider or other wrappers
+  // that break position:fixed on iOS Safari
+  if (!mounted) {
+    return null;
+  }
+
+  return createPortal(navbar, document.body);
 }

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -30,9 +30,14 @@ export default function MobileNavbar() {
 
   const navbar = (
     <nav
+      data-mobile-navbar
       className="fixed inset-x-0 bottom-0 z-[9999] flex w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
         paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))',
+        transform: 'translateZ(0)',
+        WebkitTransform: 'translateZ(0)',
+        willChange: 'transform',
+        height: 'calc(var(--navbar-height, 68px) + env(safe-area-inset-bottom, 0px))',
       }}
     >
       <Link href={`/${currencyQueryString}`} className={getMobileLinkClasses(pathname === '/')}>

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -1,6 +1,5 @@
 'use client';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { HomeIcon } from '../icons/HomeIcon';
 import { PortfolioIcon } from '../icons/PortfolioIcon';
@@ -17,41 +16,17 @@ const getMobileLinkClasses = (isActive: boolean) => {
 };
 
 export default function MobileNavbar() {
-  const [visualBottomOffset, setVisualBottomOffset] = useState(0);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currencyParam = searchParams?.get('currency');
   const currencyQueryString = currencyParam ? `?currency=${currencyParam}` : '';
 
-  useEffect(() => {
-    const viewport = window.visualViewport;
-    if (!viewport) return;
-
-    const updateOffset = () => {
-      const offset = Math.max(0, window.innerHeight - (viewport.height + viewport.offsetTop));
-      setVisualBottomOffset(offset);
-    };
-
-    updateOffset();
-    viewport.addEventListener('resize', updateOffset);
-    viewport.addEventListener('scroll', updateOffset);
-    window.addEventListener('orientationchange', updateOffset);
-
-    return () => {
-      viewport.removeEventListener('resize', updateOffset);
-      viewport.removeEventListener('scroll', updateOffset);
-      window.removeEventListener('orientationchange', updateOffset);
-    };
-  }, []);
-
   return (
     <nav
       className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
-        bottom: `calc(${visualBottomOffset}px + var(--mobile-nav-safe, env(safe-area-inset-bottom)))`,
+        bottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
         paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
-        WebkitTransform: 'translateZ(0)',
-        transform: 'translateZ(0)',
       }}
     >
       <Link href={`/${currencyQueryString}`} className={getMobileLinkClasses(pathname === '/')}>

--- a/src/app/components/MobileNavbar.tsx
+++ b/src/app/components/MobileNavbar.tsx
@@ -23,9 +23,11 @@ export default function MobileNavbar() {
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-[9999] flex w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
+      className="fixed inset-x-0 bottom-0 z-[9999] flex h-[var(--mobile-nav-total-height,72px)] w-full items-center justify-around border-t border-gray-200 bg-white/95 px-4 pt-3 backdrop-blur-xl dark:border-gray-800/50 dark:bg-[#13121A]/95 sm:hidden"
       style={{
-        paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
+        paddingBottom: 'var(--mobile-nav-safe, env(safe-area-inset-bottom))',
+        WebkitTransform: 'translateZ(0)',
+        transform: 'translateZ(0)',
       }}
     >
       <Link href={`/${currencyQueryString}`} className={getMobileLinkClasses(pathname === '/')}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,25 @@ body {
   min-height: -webkit-fill-available;
 }
 
+@supports (height: 100dvh) {
+  html,
+  body {
+    min-height: 100dvh;
+  }
+}
+
+@media (max-width: 639px) {
+  :root {
+    --mobile-nav-height: 68px;
+    --mobile-nav-safe: env(safe-area-inset-bottom, 0px);
+    --mobile-nav-total-height: calc(var(--mobile-nav-height) + var(--mobile-nav-safe));
+  }
+
+  body {
+    padding-bottom: var(--mobile-nav-total-height);
+  }
+}
+
 /* Prevent overscroll bounce on iOS */
 @supports (padding-bottom: env(safe-area-inset-bottom)) {
   html,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,10 +2,51 @@
 @tailwind components;
 @tailwind utilities;
 
+/* CSS Custom Properties for Mobile Navbar */
+:root {
+  --navbar-height: 68px;
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --navbar-total-height: calc(var(--navbar-height) + var(--safe-area-bottom));
+}
+
+/* iOS Safari viewport fixes */
+html {
+  height: 100%;
+  /* Support for dynamic viewport height on modern browsers */
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body {
+  min-height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+/* iOS-specific fixes using feature detection */
+@supports (-webkit-touch-callout: none) {
+  /* iOS Safari only */
+  html {
+    height: -webkit-fill-available;
+  }
+  
+  body {
+    min-height: -webkit-fill-available;
+  }
+  
+  /* Additional fixed positioning optimization for iOS */
+  [data-mobile-navbar] {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -webkit-perspective: 1000;
+    perspective: 1000;
+  }
+}
+
 /* Mobile navbar spacing - ensures content doesn't scroll behind fixed navbar */
 @media (max-width: 639px) {
   body {
-    padding-bottom: calc(68px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: var(--navbar-total-height);
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,6 @@
 html {
   height: 100%;
   height: -webkit-fill-available;
-  -webkit-overflow-scrolling: touch;
 }
 
 body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,42 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Base document sizing tuned for iOS Safari dynamic viewport */
-html,
-body {
-  height: 100%;
-  min-height: 100vh;
-}
-
-@supports (height: 100dvh) {
-  html,
-  body {
-    min-height: 100dvh;
-  }
-}
-
-body {
-  position: relative;
-  overflow-x: hidden;
-}
-
-:root {
-  --mobile-nav-height: 68px;
-  --mobile-nav-safe: env(safe-area-inset-bottom, 0px);
-  --mobile-nav-total-height: calc(var(--mobile-nav-height) + var(--mobile-nav-safe));
-}
-
+/* Mobile navbar spacing - ensures content doesn't scroll behind fixed navbar */
 @media (max-width: 639px) {
   body {
-    padding-bottom: var(--mobile-nav-total-height);
-  }
-}
-
-/* Prevent overscroll bounce on iOS */
-@supports (padding-bottom: env(safe-area-inset-bottom)) {
-  html,
-  body {
-    overscroll-behavior-y: none;
+    padding-bottom: calc(68px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,13 +20,13 @@ body {
   }
 }
 
-@media (max-width: 639px) {
-  :root {
-    --mobile-nav-height: 68px;
-    --mobile-nav-safe: env(safe-area-inset-bottom, 0px);
-    --mobile-nav-total-height: calc(var(--mobile-nav-height) + var(--mobile-nav-safe));
-  }
+:root {
+  --mobile-nav-height: 68px;
+  --mobile-nav-safe: env(safe-area-inset-bottom, 0px);
+  --mobile-nav-total-height: calc(var(--mobile-nav-height) + var(--mobile-nav-safe));
+}
 
+@media (max-width: 639px) {
   body {
     padding-bottom: var(--mobile-nav-total-height);
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,15 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-/* iOS Safari height and scroll fixes */
-html {
-  height: 100%;
-  height: -webkit-fill-available;
-}
-
+/* Base document sizing tuned for iOS Safari dynamic viewport */
+html,
 body {
-  min-height: 100%;
-  min-height: -webkit-fill-available;
+  height: 100%;
+  min-height: 100vh;
 }
 
 @supports (height: 100dvh) {
@@ -18,6 +14,11 @@ body {
   body {
     min-height: 100dvh;
   }
+}
+
+body {
+  position: relative;
+  overflow-x: hidden;
 }
 
 :root {


### PR DESCRIPTION
- Change paddingBottom from max() to calc() for consistent safe area handling
- Remove translate3d transform as it was not solving the iOS Safari issue
- Remove -webkit-overflow-scrolling as it can cause issues with fixed positioning
- Focus on -webkit-fill-available height fix for proper viewport handling