### PR TITLE
fix: disable Next.js image optimization to avoid Vercel free tier limit

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Set unoptimized: true in next.config.mjs to bypass Vercel's 5,000 monthly transformation limit. CoinGecko images are already optimized and CDN-hosted, so additional optimization by Vercel is unnecessary and was hitting the free tier cap during development.

This resolves the image transformation quota issue while maintaining all Next.js Image component benefits (lazy loading, layout shift prevention, etc).