### PR TITLE
fix(android): add ViewportHeightFix to handle Android viewport height…

### DIFF
--- a/src/app/components/ViewportHeightFix.tsx
+++ b/src/app/components/ViewportHeightFix.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ViewportHeightFix() {
+  useEffect(() => {
+    const setVh = () => {
+      const height = window.visualViewport?.height ?? window.innerHeight;
+      document.documentElement.style.setProperty('--app-vh', `${height * 0.01}px`);
+    };
+
+    setVh();
+    window.addEventListener('resize', setVh);
+    window.visualViewport?.addEventListener('resize', setVh);
+
+    return () => {
+      window.removeEventListener('resize', setVh);
+      window.visualViewport?.removeEventListener('resize', setVh);
+    };
+  }, []);
+
+  return null;
+}
+

--- a/src/app/components/ViewportHeightFix.tsx
+++ b/src/app/components/ViewportHeightFix.tsx
@@ -21,4 +21,3 @@ export default function ViewportHeightFix() {
 
   return null;
 }
-

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,8 +27,7 @@ body {
 
 /* App shell uses dynamic viewport height on mobile */
 #app-shell {
-  height: 100vh;
-  height: 100dvh;
+  height: calc(var(--app-vh, 1vh) * 100);
 }
 
 /* iOS-specific fixes using feature detection */
@@ -45,7 +44,7 @@ body {
   #app-shell {
     height: -webkit-fill-available;
   }
-  
+
   /* Additional fixed positioning optimization for iOS */
   [data-mobile-navbar] {
     -webkit-backface-visibility: hidden;
@@ -55,6 +54,21 @@ body {
     /* iOS Safari + backdrop-filter on fixed elements can jitter while scrolling */
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
+  }
+}
+
+@supports (height: 100dvh) {
+  #app-shell {
+    height: 100dvh;
+  }
+}
+
+/* Lock page scrolling to #app-scroll on mobile */
+@media (max-width: 639px) {
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from './components/Navbar';
 import NavbarSkeleton from './components/NavbarSkeleton';
 import MobileNavbar from './components/MobileNavbar';
 import MarketDataHeader from './components/MarketDataHeader';
+import ViewportHeightFix from './components/ViewportHeightFix';
 import { Providers } from './providers';
 
 const spaceGrotesk = Space_Grotesk({
@@ -34,6 +35,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${spaceGrotesk.className} bg-[#F3F5F9] dark:bg-[#13121A]`}>
         <Providers>
+          <ViewportHeightFix />
           <div
             id="app-shell"
             className="relative flex h-dvh min-h-dvh flex-col sm:h-screen sm:min-h-screen"


### PR DESCRIPTION
… issues

Added ViewportHeightFix client helper at src/app/components/ViewportHeightFix.tsx to set --app-vh from visualViewport.height/innerHeight and update on resize.

Wired it into src/app/layout.tsx so it runs once app-wide.

Updated src/app/globals.css:
- #app-shell now uses height: calc(var(--app-vh, 1vh) * 100) with 100dvh override when supported and -webkit-fill-available on iOS.
- Mobile-only html, body { height:100%; overflow:hidden; } so Android scrolls only inside #app-scroll and the absolute nav can't drift.